### PR TITLE
Handle autocommand error in 0.10.0

### DIFF
--- a/lua/prefab/init.lua
+++ b/lua/prefab/init.lua
@@ -50,13 +50,19 @@ local setup = function(args)
             on_attach = function(client, bufnr)
                 if not skip_responsiveness_handlers then
                     if client.supports_method("textDocument/codeLens") then
+                        local group_id =
+                            vim.api.nvim_create_augroup(
+                                "PrefabCodeLensResponsiveness", {})
+
                         vim.api.nvim_create_autocmd({
                             'BufEnter', 'BufWritePre', 'CursorHold'
                         }, {
+                            group = group_id,
+
                             buffer = bufnr,
 
                             callback = function()
-                                vim.lsp.codelens.refresh()
+                                vim.lsp.codelens.refresh({bufnr = bufnr})
                             end
                         })
                     end


### PR DESCRIPTION
Not present in 0.10.1, the root problem seems to be that the
codelens.refresh can fire against another buffer than the one the
autocommand is attached to. I'm entirely sure if this is a race
condition, but you could trigger this by swapping from a file where
codelens is supported (e.g. ruby) to one where codelens isn't supported
(e.g. json).

The error was

```
Error detected while processing CursorHold Autocommands for "<buffer=3>":
method textDocument/codeLens is not supported by any of the servers registered for the current buffer
```

Setting the bufnr on the refresh takes care of this issue.

Though it was unrelated to any observable issue (e.g. there was no
autocommand pile-up) , I'm also setting an auggroup now as well.
